### PR TITLE
Add the possibility to choose the run taken for the main metric

### DIFF
--- a/dashboard_utils/main_metrics.py
+++ b/dashboard_utils/main_metrics.py
@@ -5,7 +5,7 @@ import wandb
 
 from dashboard_utils.time_tracker import _log, simple_time_tracker
 
-WANDB_REPO = st.secrets["WANDB_REPO_MAIN_METRICS"] 
+WANDB_RUN_URL = st.secrets["WANDB_RUN_URL_MAIN_METRICS"] 
 CACHE_TTL = 100
 
 
@@ -13,8 +13,7 @@ CACHE_TTL = 100
 @simple_time_tracker(_log)
 def get_main_metrics():
     api = wandb.Api()
-    runs = api.runs(WANDB_REPO)
-    run = runs[0]
+    run = api.run(WANDB_RUN_URL)
     history = run.scan_history(keys=["step", "loss", "alive peers", "_timestamp"])
 
     steps = []


### PR DESCRIPTION
The purpose of this change is to be able to choose the run that will be used for the main metrics. 

The information must therefore be entered as secrets in the spaces in the `<entity>/<project>/<run_id>` (without quotation marks)  format with the `WANDB_RUN_URL_MAIN_METRICS` key.

cc @borzunov, @justheuristic for info